### PR TITLE
Add DOCTYPE to boilerplate

### DIFF
--- a/boilerplate.md
+++ b/boilerplate.md
@@ -25,6 +25,7 @@ Change the page wrapper from <code><div class="site" id="page"></code> to <code>
 
 <button class="btn copy" title="Copy code to clipboard" data-clipboard-target=".highlight"><i class="fa fa-clipboard"></i></button>
 {% highlight html %}
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
Just noticed the boilerplate doesn't have the doctype at the top. I've seen weird things happen once in a while when this is missing. From Mozilla's docs:

> Doing so will cause even browsers that don't presently support HTML5 to enter into standards mode, which means that they'll interpret the long-established parts of HTML in an HTML5-compliant way while ignoring the new features of HTML5 they don't support.
