### PR TITLE
right-align nav in application header

### DIFF
--- a/_patterns/global/003-header-app.html
+++ b/_patterns/global/003-header-app.html
@@ -28,7 +28,7 @@ description: Application Header, with app name next to logo. Please note the cla
       </div>
     </div>
     <div class="large-8 columns">
-      <nav>
+      <nav class="right">
         <a class="button" href="#/">Button 1</a>
         <a class="button" href="#/">Button 2</a>
       </nav>


### PR DESCRIPTION
without this, if you don't have enough buttons to fill the space, they get left-aligned. assuming that's not intentional